### PR TITLE
Added support for Pathauto module.

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -2,7 +2,7 @@
 ##
 # Build.
 #
-# shellcheck disable=SC2015
+# shellcheck disable=SC2015,SC2094
 
 set -e
 
@@ -26,7 +26,7 @@ if [ -n "${DRUPAL_PROJECT_SHA}" ] && [ -n "${DRUPAL_VERSION}" ] ; then
   cat build/composer.json
 
   echo "==> Install dependencies"
-  php -d memory_limit=-1 $(which composer) --working-dir=build install
+  php -d memory_limit=-1 "$(command -v composer)" --working-dir=build install
 else
   echo "==> Initialise Drupal site from the latest scaffold"
   composer create-project drupal-composer/drupal-project:8.x-dev build --no-interaction
@@ -34,7 +34,7 @@ fi
 
 echo "==> Install additional dev dependencies from module's composer.json"
 cat <<< "$(jq --indent 4 -M -s '.[0] * .[1]' composer.json build/composer.json)" > build/composer.json
-php -d memory_limit=-1 $(which composer) --working-dir=build update --lock
+php -d memory_limit=-1 "$(command -v composer)" --working-dir=build update --lock
 
 echo "==> Install other dev dependencies"
 composer --working-dir=build require --dev dealerdirect/phpcodesniffer-composer-installer:^0.5

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -32,7 +32,11 @@ else
   composer create-project drupal-composer/drupal-project:8.x-dev build --no-interaction
 fi
 
-echo "==> Install additional dev dependencies"
+echo "==> Install additional dev dependencies from module's composer.json"
+cat <<< "$(jq --indent 4 -M -s '.[0] * .[1]' composer.json build/composer.json)" > build/composer.json
+php -d memory_limit=-1 $(which composer) --working-dir=build update --lock
+
+echo "==> Install other dev dependencies"
 composer --working-dir=build require --dev dealerdirect/phpcodesniffer-composer-installer:^0.5
 
 echo "==> Start inbuilt PHP server in $(pwd)/build/web"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ aliases:
 job-build: &job-build
     steps:
       - checkout
-      - run: sudo -E apt-get update && sudo -E apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libpng-dev && sudo -E docker-php-ext-install -j$(nproc) iconv && sudo -E docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && sudo -E docker-php-ext-install -j$(nproc) gd
+      - run: sudo -E apt-get update && sudo -E apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libpng-dev jq && sudo -E docker-php-ext-install -j$(nproc) iconv && sudo -E docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && sudo -E docker-php-ext-install -j$(nproc) gd
       - run: .circleci/build.sh
       - run: .circleci/lint.sh
       - run: .circleci/test.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,21 +9,21 @@ aliases:
       - image: circleci/php:7.3-cli-browsers
 
 job-build: &job-build
-    steps:
-      - checkout
-      - run: sudo -E apt-get update && sudo -E apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libpng-dev jq && sudo -E docker-php-ext-install -j$(nproc) iconv && sudo -E docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && sudo -E docker-php-ext-install -j$(nproc) gd
-      - run: .circleci/build.sh
-      - run: .circleci/lint.sh
-      - run: .circleci/test.sh
-      - run:
-          command: .circleci/process-artifacts.sh
-          when: always
-      - store_test_results:
-          path: /tmp/test_results
-          when: always
-      - store_artifacts:
-          path: /tmp/artifacts
-          when: always
+  steps:
+    - checkout
+    - run: sudo -E apt-get update && sudo -E apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libpng-dev jq && sudo -E docker-php-ext-install -j$(nproc) iconv && sudo -E docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && sudo -E docker-php-ext-install -j$(nproc) gd
+    - run: .circleci/build.sh
+    - run: .circleci/lint.sh
+    - run: .circleci/test.sh
+    - run:
+        command: .circleci/process-artifacts.sh
+        when: always
+    - store_test_results:
+        path: /tmp/test_results
+        when: always
+    - store_artifacts:
+        path: /tmp/artifacts
+        when: always
 
 jobs:
   build-php-7.3:

--- a/.circleci/lint.sh
+++ b/.circleci/lint.sh
@@ -7,4 +7,4 @@ set -e
 MODULE=$(basename -s .info.yml -- ./*.info.yml)
 
 echo "==> Lint code"
-build/vendor/bin/phpcs -s --standard=Drupal,DrupalPractice --extensions=module,php,install,inc,test,yml,js "build/web/modules/${MODULE}"
+build/vendor/bin/phpcs -s --standard=Drupal,DrupalPractice --extensions=module,php,install,inc,test,info.yml,js "build/web/modules/${MODULE}"

--- a/.circleci/lint.sh
+++ b/.circleci/lint.sh
@@ -7,4 +7,4 @@ set -e
 MODULE=$(basename -s .info.yml -- ./*.info.yml)
 
 echo "==> Lint code"
-build/vendor/bin/phpcs -s --standard=Drupal,DrupalPractice "build/web/modules/${MODULE}"
+build/vendor/bin/phpcs -s --standard=Drupal,DrupalPractice --extensions=module,php,install,inc,test,yml,js "build/web/modules/${MODULE}"

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -18,4 +18,5 @@ php ./build/web/core/scripts/run-tests.sh \
   --xml /tmp/test_results/simpletest \
   --color \
   --verbose \
+  --suppress-deprecations \
   --module "${MODULE}"

--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,8 @@
     "source": "https://git.drupalcode.org/project/minisite"
   },
   "minimum-stability": "dev",
-  "prefer-stable": true
+  "prefer-stable": true,
+  "require-dev": {
+    "drupal/pathauto": "~1.0"
+  }
 }

--- a/minisite.info.yml
+++ b/minisite.info.yml
@@ -5,3 +5,5 @@ package: Field types
 core: 8.x
 dependencies:
   - drupal:file
+recommends:
+  - pathauto:pathauto

--- a/minisite.install
+++ b/minisite.install
@@ -119,7 +119,7 @@ function minisite_schema() {
         'default' => '',
       ],
       'source' => [
-        'description' => 'The asset file source URI.',
+        'description' => 'The URI of the source asset file.',
         'type' => 'varchar',
         'length' => 2048,
         'not null' => TRUE,
@@ -144,18 +144,11 @@ function minisite_schema() {
         'entity_id',
         'entity_language',
         'field_name',
-        'source',
       ],
     ],
     'indexes' => [
-      'entity_type' => ['entity_type'],
-      'entity_bundle' => ['entity_bundle'],
-      'entity_id' => ['entity_id'],
-      'entity_rid' => ['entity_rid'],
-      'entity_language' => ['entity_language'],
-      'field_name' => ['field_name'],
-      'source' => ['source'],
-      'alias' => ['alias'],
+      'source' => [['source', 170]],
+      'alias' => [['alias', 170]],
     ],
   ];
 

--- a/minisite.module
+++ b/minisite.module
@@ -96,32 +96,6 @@ function minisite_validate_archive(FileInterface $file, $content_extensions) {
 }
 
 /**
- * Implements hook_entity_update().
- */
-function minisite_entity_update(EntityInterface $entity) {
-  if (!$entity instanceof FieldableEntityInterface) {
-    return;
-  }
-
-  /** @var \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager */
-  $entity_field_manager = Drupal::service('entity_field.manager');
-  /** @var \Drupal\Core\Field\FieldDefinitionInterface[] $minisite_fields */
-  $minisite_fields = array_filter($entity_field_manager->getFieldDefinitions($entity->getEntityTypeId(), $entity->bundle()), function (FieldDefinitionInterface $field_definition) {
-    return $field_definition->getType() == 'minisite';
-  });
-
-  /** @var \Drupal\Core\Entity\FieldableEntityInterface $entity */
-  foreach ($minisite_fields as $minisite_field) {
-    if ($entity->hasField($minisite_field->getName())) {
-      $minisite = Minisite::createInstance($entity->{$minisite_field->getName()});
-      if ($minisite) {
-        $minisite->save();
-      }
-    }
-  }
-}
-
-/**
  * Implements hook_entity_delete().
  */
 function minisite_entity_delete(EntityInterface $entity) {

--- a/minisite.module
+++ b/minisite.module
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Url;
 use Drupal\file\FileInterface;
 use Drupal\minisite\AssetInterface;
 use Drupal\minisite\Exception\ArchiveException;
@@ -93,6 +94,64 @@ function minisite_validate_archive(FileInterface $file, $content_extensions) {
   }
 
   return $errors;
+}
+
+/**
+ * Implements hook_path_insert().
+ */
+function minisite_path_insert($path) {
+  $params = Url::fromUri("internal:" . $path['source'])->getRouteParameters();
+  $entity_type = key($params);
+  $entity = \Drupal::entityTypeManager()->getStorage($entity_type)->load($params[$entity_type]);
+
+  if ($entity) {
+    /** @var \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager */
+    $entity_field_manager = Drupal::service('entity_field.manager');
+    /** @var \Drupal\Core\Field\FieldDefinitionInterface[] $minisite_fields */
+    $minisite_fields = array_filter($entity_field_manager->getFieldDefinitions($entity->getEntityTypeId(), $entity->bundle()), function (FieldDefinitionInterface $field_definition) {
+      return $field_definition->getType() == 'minisite';
+    });
+
+    /** @var \Drupal\Core\Entity\FieldableEntityInterface $entity */
+    foreach ($minisite_fields as $minisite_field) {
+      if ($entity->hasField($minisite_field->getName())) {
+        $minisite = Minisite::createInstance($entity->{$minisite_field->getName()});
+        if ($minisite) {
+          $minisite->setAlias($path['alias']);
+          $minisite->save();
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_path_update().
+ */
+function minisite_path_update($path) {
+  $params = Url::fromUri("internal:" . $path['source'])->getRouteParameters();
+  $entity_type = key($params);
+  $entity = \Drupal::entityTypeManager()->getStorage($entity_type)->load($params[$entity_type]);
+
+  if ($entity) {
+    /** @var \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager */
+    $entity_field_manager = Drupal::service('entity_field.manager');
+    /** @var \Drupal\Core\Field\FieldDefinitionInterface[] $minisite_fields */
+    $minisite_fields = array_filter($entity_field_manager->getFieldDefinitions($entity->getEntityTypeId(), $entity->bundle()), function (FieldDefinitionInterface $field_definition) {
+      return $field_definition->getType() == 'minisite';
+    });
+
+    /** @var \Drupal\Core\Entity\FieldableEntityInterface $entity */
+    foreach ($minisite_fields as $minisite_field) {
+      if ($entity->hasField($minisite_field->getName())) {
+        $minisite = Minisite::createInstance($entity->{$minisite_field->getName()});
+        if ($minisite) {
+          $minisite->setAlias($path['alias']);
+          $minisite->save();
+        }
+      }
+    }
+  }
 }
 
 /**

--- a/minisite.module
+++ b/minisite.module
@@ -100,26 +100,22 @@ function minisite_validate_archive(FileInterface $file, $content_extensions) {
  * Implements hook_path_insert().
  */
 function minisite_path_insert($path) {
-  $params = Url::fromUri("internal:" . $path['source'])->getRouteParameters();
-  $entity_type = key($params);
-  $entity = \Drupal::entityTypeManager()->getStorage($entity_type)->load($params[$entity_type]);
+  $entity = _minisite_get_entity_from_path($path['source']);
 
-  if ($entity) {
-    /** @var \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager */
-    $entity_field_manager = Drupal::service('entity_field.manager');
-    /** @var \Drupal\Core\Field\FieldDefinitionInterface[] $minisite_fields */
-    $minisite_fields = array_filter($entity_field_manager->getFieldDefinitions($entity->getEntityTypeId(), $entity->bundle()), function (FieldDefinitionInterface $field_definition) {
-      return $field_definition->getType() == 'minisite';
-    });
+  if (!$entity) {
+    return;
+  }
 
-    /** @var \Drupal\Core\Entity\FieldableEntityInterface $entity */
-    foreach ($minisite_fields as $minisite_field) {
-      if ($entity->hasField($minisite_field->getName())) {
-        $minisite = Minisite::createInstance($entity->{$minisite_field->getName()});
-        if ($minisite) {
-          $minisite->setAlias($path['alias']);
-          $minisite->save();
-        }
+  $path_alias = isset($path['alias']) ? $path['alias'] : '';
+
+  $minisite_fields = _minisite_get_fields($entity);
+
+  foreach ($minisite_fields as $minisite_field) {
+    if ($entity->hasField($minisite_field->getName())) {
+      $minisite = Minisite::createInstance($entity->{$minisite_field->getName()});
+      if ($minisite) {
+        $minisite->setAlias($path_alias);
+        $minisite->save();
       }
     }
   }
@@ -129,45 +125,14 @@ function minisite_path_insert($path) {
  * Implements hook_path_update().
  */
 function minisite_path_update($path) {
-  $params = Url::fromUri("internal:" . $path['source'])->getRouteParameters();
-  $entity_type = key($params);
-  $entity = \Drupal::entityTypeManager()->getStorage($entity_type)->load($params[$entity_type]);
-
-  if ($entity) {
-    /** @var \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager */
-    $entity_field_manager = Drupal::service('entity_field.manager');
-    /** @var \Drupal\Core\Field\FieldDefinitionInterface[] $minisite_fields */
-    $minisite_fields = array_filter($entity_field_manager->getFieldDefinitions($entity->getEntityTypeId(), $entity->bundle()), function (FieldDefinitionInterface $field_definition) {
-      return $field_definition->getType() == 'minisite';
-    });
-
-    /** @var \Drupal\Core\Entity\FieldableEntityInterface $entity */
-    foreach ($minisite_fields as $minisite_field) {
-      if ($entity->hasField($minisite_field->getName())) {
-        $minisite = Minisite::createInstance($entity->{$minisite_field->getName()});
-        if ($minisite) {
-          $minisite->setAlias($path['alias']);
-          $minisite->save();
-        }
-      }
-    }
-  }
+  minisite_path_insert($path);
 }
 
 /**
  * Implements hook_entity_delete().
  */
 function minisite_entity_delete(EntityInterface $entity) {
-  if (!$entity instanceof FieldableEntityInterface) {
-    return;
-  }
-
-  /** @var \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager */
-  $entity_field_manager = Drupal::service('entity_field.manager');
-  /** @var \Drupal\Core\Field\FieldDefinitionInterface[] $minisite_fields */
-  $minisite_fields = array_filter($entity_field_manager->getFieldDefinitions($entity->getEntityTypeId(), $entity->bundle()), function (FieldDefinitionInterface $field_definition) {
-    return $field_definition->getType() == 'minisite';
-  });
+  $minisite_fields = _minisite_get_fields($entity);
 
   /** @var \Drupal\Core\Entity\FieldableEntityInterface $entity */
   foreach ($minisite_fields as $minisite_field) {
@@ -178,4 +143,48 @@ function minisite_entity_delete(EntityInterface $entity) {
       }
     }
   }
+}
+
+/**
+ * Get Minisite fields from the entity.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   Entity to get fields from.
+ *
+ * @return array
+ *   Array of Minisite field names.
+ */
+function _minisite_get_fields(EntityInterface $entity) {
+  if (!$entity instanceof FieldableEntityInterface) {
+    return [];
+  }
+
+  /** @var \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager */
+  $entity_field_manager = Drupal::service('entity_field.manager');
+
+  /** @var \Drupal\Core\Field\FieldDefinitionInterface[] $minisite_fields */
+  return array_filter($entity_field_manager->getFieldDefinitions($entity->getEntityTypeId(), $entity->bundle()), function (FieldDefinitionInterface $field_definition) {
+    return $field_definition->getType() == 'minisite';
+  });
+}
+
+/**
+ * Get entity from provided path.
+ *
+ * @param string $path
+ *   Source path to find the entity.
+ *
+ * @return \Drupal\Core\Entity\FieldableEntityInterface|null
+ *   Found entity or NULL if the entity was not found.
+ */
+function _minisite_get_entity_from_path($path) {
+  try {
+    $params = Url::fromUri('internal:' . $path)->getRouteParameters();
+  }
+  catch (\InvalidArgumentException $exception) {
+    return NULL;
+  }
+  $entity_type = key($params);
+
+  return \Drupal::entityTypeManager()->getStorage($entity_type)->load($params[$entity_type]);
 }

--- a/src/UrlBag.php
+++ b/src/UrlBag.php
@@ -144,7 +144,8 @@ class UrlBag {
   /**
    * Set parent alias.
    *
-   * This sets the "prefix" part of the alias.
+   * This sets the "prefix" part of the alias. Note that this can be empty
+   * to unset the parent part of the alias.
    *
    * @param string $parent_alias
    *   Relative or absolute path.

--- a/tests/src/Functional/MinisiteTestBase.php
+++ b/tests/src/Functional/MinisiteTestBase.php
@@ -54,6 +54,27 @@ abstract class MinisiteTestBase extends BrowserTestBase {
   protected $contentType = 'article';
 
   /**
+   * Array of admin user permissions.
+   *
+   * Can be overridden from descendant classes.
+   *
+   * @var array
+   */
+  protected $adminUserPermissions = [
+    'access content',
+    'access administration pages',
+    'administer site configuration',
+    'administer users',
+    'administer permissions',
+    'administer content types',
+    'administer node fields',
+    'administer node display',
+    'administer nodes',
+    'bypass node access',
+    'administer url aliases',
+  ];
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp() {
@@ -61,20 +82,9 @@ abstract class MinisiteTestBase extends BrowserTestBase {
 
     $this->fixtureSetUp();
 
-    $this->adminUser = $this->drupalCreateUser([
-      'access content',
-      'access administration pages',
-      'administer site configuration',
-      'administer users',
-      'administer permissions',
-      'administer content types',
-      'administer node fields',
-      'administer node display',
-      'administer nodes',
-      'bypass node access',
-      'administer url aliases',
-    ]);
+    $this->adminUser = $this->drupalCreateUser($this->adminUserPermissions);
     $this->drupalLogin($this->adminUser);
+
     $this->drupalCreateContentType(['type' => $this->contentType, 'name' => 'Article']);
   }
 

--- a/tests/src/Functional/MinisiteTestBase.php
+++ b/tests/src/Functional/MinisiteTestBase.php
@@ -468,7 +468,29 @@ abstract class MinisiteTestBase extends BrowserTestBase {
   /**
    * Helper to browse fixture pages.
    */
-  public function browseFixtureMinisite($alias, $description, $assets_paths) {
+  public function browseFixtureMinisite($node, $description) {
+    // Visit node and start browsing minisite.
+    $this->drupalGet('node/' . $node->id());
+    $this->assertResponse(200);
+    $this->assertLink($description);
+    $this->clickLink($description);
+
+    // Brose minisite pages starting from index page.
+    $this->assertText('Index page');
+    $this->assertLink('Go to Page 1');
+    $this->clickLink('Go to Page 1');
+
+    $this->assertText('Page 1');
+    $this->assertLink('Go to Page 2');
+    $this->clickLink('Go to Page 2');
+
+    $this->assertText('Page 2');
+  }
+
+  /**
+   * Helper to browse aliased fixture pages.
+   */
+  public function browseFixtureMinisiteAliased($alias, $description, $assets_paths) {
     $this->drupalGet($alias);
     $this->assertResponse(200);
 

--- a/tests/src/Functional/UploadBrowseAliasPathautoTest.php
+++ b/tests/src/Functional/UploadBrowseAliasPathautoTest.php
@@ -63,7 +63,7 @@ class UploadBrowseAliasPathautoTest extends MinisiteTestBase {
 
     // Browse fixture minisite using Pathauto-generated alias.
     $node_alias = $node->path->get(0)->getValue()['alias'];
-    $this->browseFixtureMinisite($node_alias, $minisite_description, $test_archive_assets);
+    $this->browseFixtureMinisiteAliased($node_alias, $minisite_description, $test_archive_assets);
 
     // Disable pathauto, update node's alias and assert that update has been
     // applied.
@@ -75,7 +75,7 @@ class UploadBrowseAliasPathautoTest extends MinisiteTestBase {
     $this->drupalPostForm("node/$nid/edit", $edit, $this->t('Save'));
 
     // Browse fixture minisite using updated manual alias.
-    $this->browseFixtureMinisite($node_alias_updated, $minisite_description, $test_archive_assets);
+    $this->browseFixtureMinisiteAliased($node_alias_updated, $minisite_description, $test_archive_assets);
 
     // Enable pathauto and assert that re-generated path alias has been
     // applied.
@@ -87,7 +87,7 @@ class UploadBrowseAliasPathautoTest extends MinisiteTestBase {
     $this->assertEntityAliasExists($node);
 
     // Browse fixture minisite using updated Pathauto-generated alias.
-    $this->browseFixtureMinisite($node_alias, $minisite_description, $test_archive_assets);
+    $this->browseFixtureMinisiteAliased($node_alias, $minisite_description, $test_archive_assets);
 
     // Delete node.
     $this->drupalPostForm("node/$nid/delete", [], $this->t('Delete'));

--- a/tests/src/Functional/UploadBrowseAliasTest.php
+++ b/tests/src/Functional/UploadBrowseAliasTest.php
@@ -54,7 +54,7 @@ class UploadBrowseAliasTest extends MinisiteTestBase {
 
     // Browse fixture minisite using manually provided alias.
     $node_alias = $node->path->get(0)->getValue()['alias'];
-    $this->browseFixtureMinisite($node_alias, $minisite_description, $test_archive_assets);
+    $this->browseFixtureMinisiteAliased($node_alias, $minisite_description, $test_archive_assets);
 
     // Updated node's alias and assert that update has been applied.
     $node_alias_updated = '/a' . $this->randomMachineName();
@@ -64,7 +64,14 @@ class UploadBrowseAliasTest extends MinisiteTestBase {
     $this->drupalPostForm("node/$nid/edit", $edit, $this->t('Save'));
 
     // Browse fixture minisite using updated manually provided alias.
-    $this->browseFixtureMinisite($node_alias_updated, $minisite_description, $test_archive_assets);
+    $this->browseFixtureMinisiteAliased($node_alias_updated, $minisite_description, $test_archive_assets);
+
+    // Remove node's alias and assert that update has been applied.
+    $edit = [
+      'path[0][alias]' => '',
+    ];
+    $this->drupalPostForm("node/$nid/edit", $edit, $this->t('Save'));
+    $this->browseFixtureMinisite($node, $minisite_description);
 
     // Delete node.
     $this->drupalPostForm("node/$nid/delete", [], $this->t('Delete'));

--- a/tests/src/Functional/UploadBrowseAliasTest.php
+++ b/tests/src/Functional/UploadBrowseAliasTest.php
@@ -113,8 +113,44 @@ class UploadBrowseAliasTest extends MinisiteTestBase {
     $this->assertText('Page 2');
     $this->assertUrl($node_alias . '/' . $test_archive_assets[2]);
 
+    // Updated node's alias and assert that update has been applied.
+    $node_alias_updated = '/a' . $random->name();
+    $edit = [
+      'path[0][alias]' => $node_alias_updated,
+    ];
+    $this->drupalPostForm("node/$nid/edit", $edit, $this->t('Save'));
+
+    // Visit node.
+    $this->drupalGet($node_alias_updated);
+    $this->assertResponse(200);
+    $this->assertUrl($node_alias_updated);
+
+    // Assert that a link to a minisite is present.
+    $this->assertLink($description);
+    $this->assertLinkByHref($node_alias_updated . '/' . $test_archive_assets[0]);
+
+    // Start browsing the minisite.
+    $this->clickLink($description);
+
+    // Assert first index path as aliased.
+    $this->assertUrl($node_alias_updated . '/' . $test_archive_assets[0]);
+
+    // Brose minisite pages starting from index page.
+    $this->assertText('Index page');
+    $this->assertLink('Go to Page 1');
+    $this->clickLink('Go to Page 1');
+
+    $this->assertText('Page 1');
+    $this->assertUrl($node_alias_updated . '/' . $test_archive_assets[1]);
+
+    $this->assertLink('Go to Page 2');
+    $this->clickLink('Go to Page 2');
+
+    $this->assertText('Page 2');
+    $this->assertUrl($node_alias_updated . '/' . $test_archive_assets[2]);
+
     // Delete node.
-    $this->drupalPostForm('node/' . $node->id() . '/delete', [], $this->t('Delete'));
+    $this->drupalPostForm("node/$nid/delete", [], $this->t('Delete'));
     $this->assertResponse(200);
 
     // Assert that files no longer exist.

--- a/tests/src/Functional/UploadBrowseTest.php
+++ b/tests/src/Functional/UploadBrowseTest.php
@@ -67,7 +67,7 @@ class UploadBrowseTest extends MinisiteTestBase {
     $this->drupalPostForm("node/add/$type_name", $edit, $this->t('Save'));
     $node = $this->drupalGetNodeByTitle($edit['title[0][value]']);
 
-    // Assert that files exist.
+    // Assert that file exist.
     $archive_file = File::load($node->{'field_' . $field_name}->target_id);
     $this->assertArchiveFileExist($archive_file);
     $this->assertAssetFilesExist($test_archive_assets);

--- a/tests/src/Functional/UploadBrowseTest.php
+++ b/tests/src/Functional/UploadBrowseTest.php
@@ -47,23 +47,7 @@ class UploadBrowseTest extends MinisiteTestBase {
     $this->assertMinisiteUploaded($node, $field_name, $test_archive_assets);
 
     $test_archive = $this->getUploadedArchiveFile($node, $field_name);
-
-    // Visit node and start browsing minisite.
-    $this->drupalGet('node/' . $node->id());
-    $this->assertResponse(200);
-    $this->assertLink($test_archive->getFilename());
-    $this->clickLink($test_archive->getFilename());
-
-    // Brose minisite pages starting from index page.
-    $this->assertText('Index page');
-    $this->assertLink('Go to Page 1');
-    $this->clickLink('Go to Page 1');
-
-    $this->assertText('Page 1');
-    $this->assertLink('Go to Page 2');
-    $this->clickLink('Go to Page 2');
-
-    $this->assertText('Page 2');
+    $this->browseFixtureMinisite($node, $test_archive->getFilename());
 
     // Delete node.
     $this->drupalPostForm("node/$nid/delete", [], $this->t('Delete'));


### PR DESCRIPTION
Pathauto generates aliases in a way that does not allow to use standard `postSave()` entity hooks.

So, and additional integration to handle Pathauto-generated aliases is required. Also added tests.