### PR TITLE
Added support for non-document datafiles.

### DIFF
--- a/src/AssetInterface.php
+++ b/src/AssetInterface.php
@@ -176,4 +176,9 @@ interface AssetInterface {
    */
   public function isDocument();
 
+  /**
+   * Check if asset is a data file and can be served directly.
+   */
+  public function isDatafile();
+
 }

--- a/src/Controller/AliasController.php
+++ b/src/Controller/AliasController.php
@@ -33,11 +33,11 @@ class AliasController implements ContainerAwareInterface {
   public function deliverAsset($asset_id) {
     $asset = Asset::load($asset_id);
 
-    // Only deliver documents through alias controller. There are other checks
-    // in the class itself, but this is one last gate keeping check to
-    // explicitly prevent non-documents from being served through alias
-    // callback.
-    if (!$asset || !$asset->isDocument()) {
+    // Only deliver documents and datafiles through alias controller.
+    // There are other checks in the class itself, but this is one last gate
+    // keeping check to explicitly prevent non-documents from being served
+    // through alias callback.
+    if (!$asset || (!$asset->isDocument() && !$asset->isDatafile())) {
       throw new NotFoundHttpException();
     }
 

--- a/tests/src/Functional/AssetTest.php
+++ b/tests/src/Functional/AssetTest.php
@@ -45,6 +45,7 @@ class AssetTest extends MinisiteTestBase {
     // Assert other getters.
     $this->assertEquals(Language::LANGCODE_DEFAULT, $asset->getLanguage());
     $this->assertTrue($asset->isDocument());
+    $this->assertFalse($asset->isDatafile());
     $this->assertFalse($asset->isIndex());
 
     // Assert saving.


### PR DESCRIPTION
Datafiles are files that needs to be aliased, but not processed by the page processor. Example: json, txt, xml etc.